### PR TITLE
Add RStudio install documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,28 @@ following command to install
 dataproofer_install()
 ```
 
+### RStudio
+
+If you're an RStudio user, double-check that your R Console and R Terminal are using the same environments to ensure you're using the same version of Node.js and Dataproofer.
+
+R Console
+
+```r
+Sys.getenv("PATH")
+```
+
+R Terminal
+
+```sh
+echo $PATH
+```
+
+If they do not match, you can synchronize the two by creating an `~/.Renviron` file
+
+```sh
+touch ~/.Renviron; R_PATH="PATH=$PATH"; echo $R_PATH > ~/.Renviron
+```
+
 ## Using dataproofr
 
 The most straightforward way to use the library is this:

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ R Terminal
 echo $PATH
 ```
 
-If they do not match, you can synchronize the two by creating an `~/.Renviron` file
+If they do not match, you can synchronize the two by creating an `~/.Renviron` file in the terminal.
 
 ```sh
 touch ~/.Renviron; R_PATH="PATH=$PATH"; echo $R_PATH > ~/.Renviron


### PR DESCRIPTION
## Description of changes

Added a section about RStudio and setting the environment to match the Terminal. This documentation is not specific to any particular OS according to the [RStudio documentation](https://support.rstudio.com/hc/en-us/articles/360047157094-Managing-R-with-Rprofile-Renviron-Rprofile-site-Renviron-site-rsession-conf-and-repos-conf), so we can add more specific documentation if needed.